### PR TITLE
Changing the check for libxml.

### DIFF
--- a/filter/mediacore/filter.php
+++ b/filter/mediacore/filter.php
@@ -94,10 +94,10 @@ class filter_mediacore extends moodle_text_filter {
         $dom = new DomDocument();
         $sanitized_html = mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
 
-        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
-            @$dom->loadHtml($sanitized_html);
-        } else {
+        if (defined('LIBXML_HTML_NOIMPLIED') && defined('LIBXML_HTML_NODEFDTD')) {
             @$dom->loadHtml($sanitized_html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        } else {
+            @$dom->loadHtml($sanitized_html);
         }
         $xpath = new DOMXPath($dom);
         foreach ($xpath->query('//a') as $node) {


### PR DESCRIPTION
* Cannot depend on assuming that a user with PHP 5.4.0+ has libxml 2.7.8+.

For example, we are running CentOS and have PHP from the remi repo, but libxml from epel. Our PHP version is at 5.4.44, but our libxml is 2.7.6.

I have tested this patch it is working on our Moodle system. I see that there is another branch that tries to solve this problem (https://github.com/mediacore/mediacore-moodle/tree/libxml-workaround), but wasn't sure if it is stable or working. This patch is simpler as well.